### PR TITLE
Update getpass prompt logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,13 +51,3 @@ clean:
 build: clean
 	$(PIP) install wheel setuptools_scm
 	$(PYTHON) setup.py sdist bdist_wheel
-
-
-.PHONY: release
-release: build
-	$(AWS) s3 cp --acl public-read \
-		dist/$(PKG_WHL)-$(VERSION)-py3-none-any.whl \
-		s3://gretel-opt-$(STAGE)/pub/$(PKG_WHL)/$(PKG_WHL)-latest-py3-none-any.whl
-	$(AWS) s3 cp --acl public-read \
-		dist/$(PKG_TAR)-$(VERSION).tar.gz \
-		s3://gretel-opt-$(STAGE)/pub/$(PKG_TAR)/$(PKG_TAR)-latest.tar.gz


### PR DESCRIPTION
This updates the `get_cloud_client` to only prompt if a gretel api key isn't set on the environment. With this logic, we can short circuit the blocking prompt in CI or other environments.

Miscellaneous updates
* Ran client.py through black formatter
* Removed release directive from Makefile since we're publishing to pypi