### PR TITLE
Suppress install output by default

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
-smart_open==1.10.0
+smart_open==2.1.0
 pandas==1.0.3
 ipywidgets==7.5.1
 tqdm==4.45.0

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -531,7 +531,7 @@ class Client:
 
         Prefer ``install_packages`` instead.
         """
-        logger.warn(
+        logger.warning(
             "The method, install_transformers is deprecated. Please use install_packages instead."
         )
         pkg.install_packages(self.api_key, self.host)

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -26,7 +26,7 @@ from gretel_client.errors import (
     BadRequest,
     Unauthorized,
     NotFound,
-    Forbidden
+    Forbidden,
 )
 
 
@@ -178,7 +178,7 @@ class Client:
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(Forbidden),
         stop=tenacity.stop_after_attempt(MAX_RATE_LIMIT_RETRY),
-        wait=tenacity.wait_exponential(multiplier=1, min=2, max=10)
+        wait=tenacity.wait_exponential(multiplier=1, min=2, max=10),
     )
     def _write_record_sync(self, project: str, records: Union[list, dict]):
         """Write a batch of records to Gretel's API
@@ -320,7 +320,7 @@ class Client:
     @tenacity.retry(
         retry=tenacity.retry_if_exception_type(Forbidden),
         stop=tenacity.stop_after_attempt(MAX_RATE_LIMIT_RETRY),
-        wait=tenacity.wait_exponential(multiplier=1, min=2, max=10)
+        wait=tenacity.wait_exponential(multiplier=1, min=2, max=10),
     )
     def _get_records_sync(self, project: str, params: dict, count: int = None):
         if count is not None:  # pragma: no cover
@@ -503,7 +503,7 @@ class Client:
                 nothing will happen with this value.
 
         Returns:
-            A ``Project`` instnace.
+            A ``Project`` instance.
 
         Raises:
             ``Unauthorized`` or ``BadRequest``
@@ -527,9 +527,22 @@ class Client:
             return self._create_get_project()
 
     def install_transformers(self):
-        """Installs the latest version of the Gretel Transformers package
+        """Deprecated: Installs the latest version of the Gretel Transformers package
+
+        Prefer ``install_packages`` instead.
         """
-        pkg.install_transformers(self.api_key, self.host)
+        logger.warn(
+            "The method, install_transformers is deprecated. Please use install_packages instead."
+        )
+        pkg.install_packages(self.api_key, self.host)
+
+    def install_packages(self, verbose: bool = False):
+        """Installs the latest version of the Gretel Transformers package
+
+        Args:
+            verbose: Will print all package installation messages.
+        """
+        pkg.install_packages(self.api_key, self.host, verbose)
 
 
 def get_cloud_client(prefix: str, api_key: str) -> Client:
@@ -569,7 +582,7 @@ def get_cloud_client(prefix: str, api_key: str) -> Client:
 def project_from_uri(uri: str) -> Project:
     """
     Get a Project instance from a Gretel URI string, the
-    URI string must have the following format: 
+    URI string must have the following format:
     gretel://[API_KEY]@HOSTNAME/PROJECT
 
     Example::
@@ -597,10 +610,7 @@ def project_from_uri(uri: str) -> Project:
     if not parts.path or parts.path == "/":
         raise ValueError("No project name found")
 
-    client = get_cloud_client(
-        parts.hostname.split(".")[0],
-        parts.username or username
-    )
+    client = get_cloud_client(parts.hostname.split(".")[0], parts.username or username)
 
     return client.get_project(name=parts.path.strip("/"))
 

--- a/src/gretel_client/pkg_installers.py
+++ b/src/gretel_client/pkg_installers.py
@@ -1,45 +1,66 @@
+import selectors
 import sys
 import subprocess
 
 import requests
 
 
-PKG_ENDPOINT = 'https://{}/opt/pkg'
+PKG_ENDPOINT = "https://{}/opt/pkg"
 
-TX_PKG = 'gretel-transformers'
+TX_PKG = "gretel-transformers"
 
 
 class GretelInstallError(Exception):
     pass
 
 
-def _install_pip_dependency(dep: str):
-    """Install pip dependency via a subprocess"""
-    cmd = [sys.executable, "-m", "pip", "install", dep]
-    print(f"running: {' '.join(cmd)}")
-    results = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                               stderr=subprocess.STDOUT)
-    for line in iter(results.stdout.readline, b''):  # pragma: no cover
+def read_pipe(section, p, verbose, collect=False):
+    out = [f"\n\n{section}\n{''.join(['=' for _ in range(len(section)+1)])}"]
+    if verbose and not collect:
+        print(out[0])
+    for line in iter(p.readline, b""):
         if isinstance(line, bytes):
-            print(line.decode('utf-8').strip())  # type: ignore
-        else:
+            line = line.decode("utf-8").strip()  # type: ignore
+        if verbose and not collect:
             print(line)
+        if collect:
+            out.append(line)
+
+    if verbose and collect and len(out) > 1:
+        for line in out:
+            print(line)
+
+
+def _install_pip_dependency(dep: str, verbose: bool = True):
+    """Install pip dependency via a subprocess"""
+    cmd = [sys.executable, "-m", "pip", "--disable-pip-version-check", "install", dep]
+    if verbose:
+        print(f"running: {' '.join(cmd)}")
+    results = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+    read_pipe("Install Output", results.stdout, verbose)
+    read_pipe("Errors & Warnings", results.stderr, verbose=True, collect=True)
 
 
 def _get_package_endpoint(package_identifier: str, api_key: str, host: str) -> str:
     """Retrieve package installation endpoints from Gretel API"""
-    pkg_resp = requests.get(f'{PKG_ENDPOINT.format(host)}/{package_identifier}',
-                            headers={'Authorization': api_key})
+    pkg_resp = requests.get(
+        f"{PKG_ENDPOINT.format(host)}/{package_identifier}",
+        headers={"Authorization": api_key},
+    )
 
     if pkg_resp.status_code != 200:  # pragma: no cover
-        raise GretelInstallError('Could not fetch package details from '
-                                 'endpoint.')
+        raise GretelInstallError("Could not fetch package details from " "endpoint.")
 
     details = pkg_resp.json()
-    source_pkg = details['data']['package']['wheel']
+    source_pkg = details["data"]["package"]["wheel"]
     return source_pkg
 
 
-def install_transformers(api_key: str, host: str):
+def install_transformers(api_key: str, host: str, verbose: bool = False):
+    print("Authenticating with package manager")
     package_endpoint = _get_package_endpoint(TX_PKG, api_key, host)
-    _install_pip_dependency(package_endpoint)
+
+    print("Installing packages (this might take a while)")
+    _install_pip_dependency(package_endpoint, verbose)
+    print("Completed installing Gretel packages")

--- a/src/gretel_client/pkg_installers.py
+++ b/src/gretel_client/pkg_installers.py
@@ -1,4 +1,4 @@
-import selectors
+import logging
 import sys
 import subprocess
 
@@ -6,34 +6,37 @@ import requests
 
 
 PKG_ENDPOINT = "https://{}/opt/pkg"
-
 TX_PKG = "gretel-transformers"
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(format="%(levelname)s %(filename)s: %(message)s")
+logger.setLevel(logging.INFO)
 
 
 class GretelInstallError(Exception):
     pass
 
 
-def read_pipe(section, cmd, p, verbose, collect=False):
+def read_pipe(cmd, p, verbose, log=logger.info, collect=False):
     out = [
-        f"\n{section}\n{''.join(['=' for _ in range(len(section)+1)])}",
         " ".join(cmd),
     ]
     if verbose and not collect:
         for line in out:
-            print(line)
+            log(line)
     for line in iter(p.readline, b""):
         if isinstance(line, bytes):
             line = line.decode("utf-8").strip()  # type: ignore
         if verbose and not collect:
-            print(line)
+            log(line)
         if collect:
             out.append(line)
 
-    if verbose and collect and len(out) > 2:
+    if verbose and collect and len(out) > 1:
         for line in out:
-            print(line)
-        print("")
+            log(line)
+        log("")
 
 
 def _install_pip_dependency(dep: str, verbose: bool = True):
@@ -47,11 +50,13 @@ def _install_pip_dependency(dep: str, verbose: bool = True):
         dep,
     ]
     if verbose:
-        print(f"running: {' '.join(cmd)}")
+        logger.info(f"running: {' '.join(cmd)}")
     results = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-    read_pipe("pip: Install Output", cmd, results.stdout, verbose)
-    read_pipe("pip: Errors & Warnings", cmd, results.stderr, verbose=True, collect=True)
+    read_pipe(cmd, results.stdout, verbose)
+    read_pipe(
+        cmd, results.stderr, verbose=True, log=logger.error, collect=True,
+    )
 
 
 def _get_package_endpoint(package_identifier: str, api_key: str, host: str) -> str:
@@ -69,10 +74,10 @@ def _get_package_endpoint(package_identifier: str, api_key: str, host: str) -> s
     return source_pkg
 
 
-def install_transformers(api_key: str, host: str, verbose: bool = False):
-    print("Authenticating with package manager")
+def install_packages(api_key: str, host: str, verbose: bool = False):
+    logger.info("Authenticating with package manager")
     package_endpoint = _get_package_endpoint(TX_PKG, api_key, host)
 
-    print("Installing packages (this might take a while)")
+    logger.info("Installing packages (this might take a while)")
     _install_pip_dependency(package_endpoint, verbose)
-    print("Finished installing Gretel packages")
+    logger.info("Finished installing Gretel packages")

--- a/tests/src/gretel_client/integration/test_projects.py
+++ b/tests/src/gretel_client/integration/test_projects.py
@@ -198,9 +198,6 @@ def test_create_named_project(client: Client):
         client.get_project(name=name, create=True, desc=too_long)
 
 
-def test_install_transformers(client: Client):
-    client.install_transformers()
-
 
 def test_temporary_project(client: Client):
     with temporary_project(client) as proj:

--- a/tests/src/gretel_client/unit/test_pkg_install.py
+++ b/tests/src/gretel_client/unit/test_pkg_install.py
@@ -1,7 +1,8 @@
-import pytest
 import io
 from dataclasses import dataclass
 from unittest.mock import patch
+
+import pytest
 
 from gretel_client import pkg_installers
 

--- a/tests/src/gretel_client/unit/test_pkg_install.py
+++ b/tests/src/gretel_client/unit/test_pkg_install.py
@@ -1,0 +1,58 @@
+import pytest
+import io
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from gretel_client import pkg_installers
+
+
+@dataclass
+class OptResponse:
+    status_code: int
+
+    def json(self):
+        return {"data": {"package": {"wheel": "https://path/to/package.whl"}}}
+
+
+@dataclass
+class ProcessResponse:
+    @property
+    def stdout(self):
+        return io.BytesIO(b"")
+
+    @property
+    def stderr(self):
+        return io.BytesIO(b"")
+
+
+@patch.object(pkg_installers.requests, "get")
+@patch.object(pkg_installers.subprocess, "Popen")
+def test_does_install_packages(popen, get_package):
+    popen.return_value = ProcessResponse()
+    get_package.return_value = OptResponse(status_code=200)
+    pkg_installers.install_packages("test123", "api-dev.gretel.cloud")
+
+    assert popen.call_args[0][0][-4:] == [
+        "pip",
+        "--disable-pip-version-check",
+        "install",
+        "https://path/to/package.whl",
+    ]
+
+    get_package.assert_called_with(
+        "https://api-dev.gretel.cloud/opt/pkg/gretel-transformers",
+        headers={"Authorization": "test123"},
+    )
+
+
+def test_requires_api_key():
+    with pytest.raises(TypeError):
+        pkg_installers.install_packages()  # type: ignore
+
+
+@patch.object(pkg_installers.requests, "get")
+def test_handles_api_down(get_package):
+    get_package.return_value = OptResponse(status_code=500)
+
+    with pytest.raises(pkg_installers.GretelInstallError):
+        pkg_installers.install_packages("test123", "api-dev")


### PR DESCRIPTION
When calling `install_transformers()`, command output will be suppressed by default. Errors should continue to be shown if there are any.

If there are no errors, the console output will look like

```
Authenticating with package manager
Installing packages (this might take a while)
Finished installing Gretel packages
```

If there are errors, the console output will look something like

```
Authenticating with package manager
Installing packages (this might take a while)

pip: Errors & Warnings
=======================
/Users/drew/.virtualenvs/tmp/bin/python -m pip --disable-pip-version-check install sdalkfdslkfj
ERROR: Could not find a version that satisfies the requirement sdalkfdslkfj (from versions: none)
ERROR: No matching distribution found for sdalkfdslkfj

Finished installing Gretel packages
```