### PR TITLE
Add entity detection endpoint to client

### DIFF
--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -526,6 +526,11 @@ class Client:
         if not name and create:
             return self._create_get_project()
 
+    def detect_entities(self, records: Union[List[dict], dict]):
+        if isinstance(records, dict):
+            records = [records]
+        return self._post("records/detect_entities", None, data=records).get(DATA).get(RECORDS, [])
+
     def install_transformers(self):
         """Installs the latest version of the Gretel Transformers package
         """
@@ -569,7 +574,7 @@ def get_cloud_client(prefix: str, api_key: str) -> Client:
 def project_from_uri(uri: str) -> Project:
     """
     Get a Project instance from a Gretel URI string, the
-    URI string must have the following format: 
+    URI string must have the following format:
     gretel://[API_KEY]@HOSTNAME/PROJECT
 
     Example::

--- a/tests/src/gretel_client/integration/test_client.py
+++ b/tests/src/gretel_client/integration/test_client.py
@@ -1,0 +1,51 @@
+import os
+import pytest
+
+from gretel_client.client import (
+    get_cloud_client,
+    Client,
+)
+
+API_KEY = os.getenv("GRETEL_TEST_API_KEY")
+
+
+if not API_KEY:
+    raise AttributeError("GRETEL_TEST_API_KEY must be set!")
+
+
+@pytest.fixture(scope="module")
+def client():
+    return get_cloud_client("api-dev", API_KEY)
+
+
+def test_detect_entities(client: Client):
+    payload = {"email": "test@gretel.ai"}
+    detected_entities = client.detect_entities(payload)
+
+    expected = {
+        "email": {
+            "ner": {
+                "labels": [
+                    {
+                        "text": "gretel.ai",
+                        "start": 5,
+                        "end": 14,
+                        "label": "domain_name",
+                        "source": "regex_domain_name",
+                        "score": 0.2,
+                    },
+                    {
+                        "text": "test@gretel.ai",
+                        "start": 0,
+                        "end": 14,
+                        "label": "email_address",
+                        "source": "regex_email",
+                        "score": 0.8,
+                    },
+                ]
+            }
+        }
+    }
+
+    assert len(detected_entities) == 1
+    assert detected_entities[0]["metadata"]["fields"] == expected


### PR DESCRIPTION
This adds support for sending records through Gretel's entity detection pipeline. 

For discussion:
* Do we want to do any further response transformation before returning the api response? Currently it's roughly following the return format of `_get_records_sync()`.