### PR TITLE
Update project_from_uri logic to prompt for project URI

### DIFF
--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -577,13 +577,11 @@ def _get_or_prompt(
         env_fallback: environment variable lookup key to use as fallback to ``prompt``
             and ``input_key``.
     """
-    if input_key == PROMPT_ALWAYS:
-        return getpass(prompt_message)
     if input_key == PROMPT:
         if os.getenv(env_fallback):
             return os.getenv(env_fallback)
-        else:
-            return getpass(prompt_message)
+    if input_key == PROMPT_ALWAYS or input_key == PROMPT:
+        return getpass(prompt_message)
     return input_key
 
 

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -45,7 +45,7 @@ INGEST_TIME = "ingest_time"
 PROMPT = "prompt"
 PROMPT_ALWAYS = "prompt_always"
 DEFAULT_API_ENV_KEY = "GRETEL_API_KEY"
-DEFAULT_PROJECT_URI = "GRETEL_PROJECT_URI"
+DEFAULT_PROJECT_URI = "GRETEL_URI"
 
 MAX_BATCH_SIZE = 50
 MAX_RATE_LIMIT_RETRY = 20
@@ -625,7 +625,7 @@ def project_from_uri(uri: str) -> Project:
         gretel://api.gretel.cloud/my_project
 
     Note:
-        If ``uri`` is "prompt", and your GRETEL_PROJECT_URI is unset,
+        If ``uri`` is "prompt", and your GRETEL_URI is unset,
         you will be prompted to enter a URI. If "prompt_always" is set,
         you will always be prompted for a project URI, even if a URI is
         already set on the environment. This is useful for

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -569,7 +569,14 @@ class Client:
 def _get_or_prompt(
     input_key: str, prompt_message: str, env_fallback: str
 ) -> Optional[str]:
-    """Helper function used to prompt for secrets based on env conditions."""
+    """Helper function used to prompt for secrets based on env conditions.
+
+    Args:
+        input_key: User provided input string to evaluate.
+        prompt_message: Message to display on getpass prompt based on ``input_key`` logic.
+        env_fallback: environment variable lookup key to use as fallback to ``prompt``
+            and ``input_key``.
+    """
     if input_key == PROMPT_ALWAYS:
         return getpass(prompt_message)
     if input_key == PROMPT:
@@ -616,6 +623,13 @@ def project_from_uri(uri: str) -> Project:
     omit the API key portion of the URI::
 
         gretel://api.gretel.cloud/my_project
+
+    Note:
+        If ``uri`` is "prompt", and your GRETEL_PROJECT_URI is unset,
+        you will be prompted to enter a URI. If "prompt_always" is set,
+        you will always be prompted for a project URI, even if a URI is
+        already set on the environment. This is useful for
+        Jupyter Notebooks, etc.
     """
     uri = _get_or_prompt(uri, "Enter Gretel Project URI: ", DEFAULT_PROJECT_URI)
     parts = urlparse(uri)

--- a/src/gretel_client/helpers.py
+++ b/src/gretel_client/helpers.py
@@ -81,3 +81,8 @@ def build_df_csv(
             df.to_csv(fp, index=False, header=headers, sep=",")
 
     return df
+
+
+def _is_running_from_ipython():
+    from IPython import get_ipython
+    return get_ipython() is not None

--- a/src/gretel_client/helpers.py
+++ b/src/gretel_client/helpers.py
@@ -81,8 +81,3 @@ def build_df_csv(
             df.to_csv(fp, index=False, header=headers, sep=",")
 
     return df
-
-
-def _is_running_from_ipython():
-    from IPython import get_ipython
-    return get_ipython() is not None


### PR DESCRIPTION
Updates `project_from_uri` to behave similar to `get_cloud_client`, and prompt the user for credentials based on input and env values. 

Also fixes up an issue in `test_project_from_uri_bad_string` where it would fail if `DEFAULT_API_ENV_KEY` was set on the system.