### PR TITLE
Update client to include new project params and override options

### DIFF
--- a/src/gretel_client/__init__.py
+++ b/src/gretel_client/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F401
 from .client import (
     get_cloud_client,
     Client,
@@ -6,4 +7,4 @@ from .client import (
     Unauthorized,
     Forbidden,
     project_from_uri
-)  # noqa
+)

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -189,7 +189,7 @@ class Client:
             A tuple containing headers, params
 
         Raises:
-            AttributeError if extracted header or param object is not of type dict.
+            AttributeError if extracted header or param object is not of type ``dict``.
         """
         headers = kwargs.get("headers", {})
         params = kwargs.get("params", {})

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -377,7 +377,7 @@ class Client:
     def __iter_records(
         self,
         project: str,
-        entity_stream: str = None,
+        entity_stream: Optional[str] = None,
         position: Optional[str] = None,
         post_process: Callable = None,
         direction: str = "forward",
@@ -395,7 +395,7 @@ class Client:
         # setup base params for streams request
         headers, params = self._headers_params_from_kwargs(**kwargs)
         params.update({"with_meta": "yes", "flatten": "yes"})
-        if entity_stream:
+        if entity_stream is not None:
             params["entity_stream"] = entity_stream
 
         stream_start_time = time.time()
@@ -450,9 +450,9 @@ class Client:
         self,
         *,
         project: str,
-        entity_stream: str = None,
+        entity_stream: Optional[str] = None,
         position: Optional[str] = None,
-        post_process: Callable = None,
+        post_process: Optional[Callable] = None,
         direction: str = "forward",
         record_limit: int = -1,
         wait_for: int = -1,

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -129,14 +129,14 @@ class Client:
             self.session.headers.update({"Authorization": self.api_key})
 
     @_api_call("get")
-    def _get(self, resource, *args, **kwargs):
+    def _get(self, resource: str, *args, **kwargs):
         headers, params = self._headers_params_from_kwargs(**kwargs)
         return self.session.get(
             self.base_url + resource, params=params, timeout=TIMEOUT, headers=headers
         )
 
     @_api_call("post")
-    def _post(self, resource, data: dict, **kwargs):
+    def _post(self, resource: str, *, data: dict, **kwargs):
         if data is not None:
             data = json.dumps(data)
         headers, params = self._headers_params_from_kwargs(**kwargs)
@@ -191,7 +191,8 @@ class Client:
         Raises:
             AttributeError if extracted header or param object is not of type dict.
         """
-        headers, params = kwargs.get("headers", {}), kwargs.get("params", {})
+        headers = kwargs.get("headers", {})
+        params = kwargs.get("params", {})
 
         if not isinstance(headers, dict):
             raise AttributeError("headers kwarg is not of type dict")
@@ -212,6 +213,8 @@ class Client:
         Args:
             project: Target Gretel project identifier.
             records: An array of records to write to the api.
+            headers: supports custom header params via kwargs
+            params: supports custom query params via kwargs
         """
         if isinstance(records, dict):
             records = [records]
@@ -279,8 +282,8 @@ class Client:
             use_progress_widget: For use inside a jupyter notebook
                 environment. If set to `true` it will try and use tqdm's
                 ipywidget instead of a text based progress indicator.
-            params:
-            headers:
+            headers: supports custom header params via kwargs
+            params: supports custom query params via kwargs
         """
         sampler.set_source(iter(reader))
         write_queue = Queue(max_inflight_batches)  # backpressured worker queue
@@ -358,6 +361,13 @@ class Client:
         wait=tenacity.wait_exponential(multiplier=1, min=2, max=10),
     )
     def _get_records_sync(self, project: str, *args, **kwargs):
+        """Returns a list of records from the streams api
+
+        Args:
+            project: project to stream records from
+            headers: supports custom header params via kwargs
+            params: supports custom query params via kwargs
+        """
         return (
             self._get(f"streams/records/{project}", **kwargs)
             .get(DATA)
@@ -469,6 +479,8 @@ class Client:
             wait_for: Time in seconds to wait for new records to arrive
                 before closing the iterator. If the number is set to a
                 value less than 0, the iterator will wait indefinitely.
+            headers: supports custom header params via kwargs
+            params: supports custom query params via kwargs
 
         Yields:
             An individual record object. If no `record_limit` is passed and

--- a/src/gretel_client/projects.py
+++ b/src/gretel_client/projects.py
@@ -176,7 +176,8 @@ class Project:
 
     def _patch_params(self, kwargs: dict, key: str, value: str) -> dict:
         """Patch in named arguments into query param **kwarg type dictionary"""
-        assert isinstance(kwargs, dict)
+        if not isinstance(kwargs, dict):
+            raise ValueError("kwargs must be a dictionary")
         if "params" in kwargs:
             kwargs["params"][key] = value
         else:

--- a/src/gretel_client/projects.py
+++ b/src/gretel_client/projects.py
@@ -114,6 +114,8 @@ class Project:
             wait_for: Time in seconds to wait for new records to arrive
                 before closing the iterator. If the number is set to a
                 value less than 0, the iterator will wait indefinitely.
+            entity_stream: Return a record stream that only contains records
+                containing a specifc entity label.
             headers: (dict) Define additional http request headers.
             params: (dict) Pass custom request query parameters.
 
@@ -159,7 +161,7 @@ class Project:
             data: a dict or a list of dicts
             detection_mode: Determines how to route the record through Gretel's entity
                 detection pipeline. Valid options include "fast", "all" and "none".
-                Selecting "all" will pass the records through a NLP pipeline, but
+                Selecting "all" will pass the records through a ML/NLP pipeline, but
                 may increase processing latency. Selecting "none" will skip the
                 detection pipeline entirely.
             headers: (dict) Define additional http request headers.
@@ -201,7 +203,7 @@ class Project:
             data: A dict or a list of dicts.
             detection_mode: Determines how to route the record through Gretel's entity
                 detection pipeline. Valid options include "fast", "all" and "none".
-                Selecting "all" will pass the record through a NLP pipeline, but
+                Selecting "all" will pass the record through a ML/NLP pipeline, but
                 may increase processing latency. Selecting "none" will skip the
                 entity detection pipeline entirely.
             headers: (dict) Pass in custom http headers to the request.
@@ -236,7 +238,7 @@ class Project:
                 of the DataFrame's rows.
             detection_mode: Determines how to route the record through Gretel's entity
                 detection pipeline. Valid options include "fast", "all" and "none".
-                Selecting "all" will pass the records through a NLP pipeline, but
+                Selecting "all" will pass the records through a ML/NLP pipeline, but
                 may increase processing latency. Selecting "none" will skip the
                 detection pipeline entirely.
             headers: (dict) Pass in custom http headers to the request.

--- a/src/gretel_client/projects.py
+++ b/src/gretel_client/projects.py
@@ -1,7 +1,7 @@
 """
 High level API for interacting with a Gretel Project
 """
-from typing import TYPE_CHECKING, List, Union, Tuple
+from typing import Dict, TYPE_CHECKING, List, Union, Tuple
 from functools import partial
 from copy import deepcopy
 
@@ -13,17 +13,21 @@ try:
     from pandas import DataFrame as _DataFrameT
 except ImportError:  # pragma: no cover
     pd = None
-    class _DataFrameT: ... # noqa
+
+    class _DataFrameT:
+        ...  # noqa
 
 
 if TYPE_CHECKING:  # pragma: no cover
     from gretel_client.client import Client, WriteSummary
 
+DEFAULT_DETECTION_MODE = "fast"
+
 
 class Project:
     """Representation of a single Gretel project. In general you should not have
     to init this class directly, but can make use of the factory method from a
-    ``Client`` instnace.
+    ``Client`` instance.
 
     Using the factory method::
 
@@ -31,9 +35,23 @@ class Project:
 
         client = get_cloud_client('api', 'your_api_key')
         project = client.get_project(create=True)  # creates a project with an auto-named slug
+
+
+    **Customizing the request**
+
+    The ``Project`` class wraps Gretel's REST api under the hood. While most query params
+    are represented as named keyword arguments, it's possible to pass in custom query
+    parameters via ``params``, or headers via ``headers``.
+
+    For example::
+
+        project.iter_records(project="test", params={"regex_query": "(cc|credit_card)"})
+
     """
 
-    def __init__(self, *, name: str, client: "Client", project_id: str, desc: str = None):
+    def __init__(
+        self, *, name: str, client: "Client", project_id: str, desc: str = None
+    ):
         self.name = name
         """The unique name of the project. This is either set by you or auto
         managed by Gretel
@@ -96,6 +114,8 @@ class Project:
             wait_for: Time in seconds to wait for new records to arrive
                 before closing the iterator. If the number is set to a
                 value less than 0, the iterator will wait indefinitely.
+            headers: (dict) Pass in custom http headers to the request.
+            params: (dict) Pass custom query parameters to the request.
 
         Yields:
             An individual record object. If no `record_limit` is passed and
@@ -108,20 +128,25 @@ class Project:
         """
         return self._iter_records(**kwargs)
 
-    def flush(self):
+    def flush(self, **kwargs):
         """This will flush all project data from the Gretel metastore.
 
         This includes all Field, Entity, and cached Record information
 
         NOTE:
-            This command runs asyncronously. When it returns, it
+            This command runs asynchronously. When it returns, it
             means it has only triggered the flush operation in Gretel. This
             full operations may take several seconds to complete.
         """
-        self.client._flush_project(self.project_id)
+        self.client._flush_project(self.project_id, **kwargs)
 
-    def send(self, data: Union[List[dict], dict]) -> Tuple[list, list]:
-        """Write one or more records syncronously. This is similar
+    def send(
+        self,
+        data: Union[List[dict], dict],
+        detection_mode: str = DEFAULT_DETECTION_MODE,
+        **kwargs,
+    ) -> Tuple[list, list]:
+        """Write one or more records synchronously. This is similar
         to making a single API call to the records endpoint. You will also
         receive the success and failure arrays back which contain the Gretel IDs
         that were generated for each ingested record.
@@ -132,14 +157,28 @@ class Project:
 
         Args:
             data: a dict or a list of dicts
+            detection_mode: Determines how to route the record through Gretel's entity
+                detection pipeline. Valid options include "fast", "all" and "none".
+                Selecting "all" will pass the records through a NLP pipeline, but
+                may increase processing latency. Selecting "none" will skip the
+                detection pipeline entirely.
+            headers: (dict) Pass in custom http headers to the request.
+            params: (dict) Pass custom query parameters to the request.
 
         Returns:
             A tuple of (success, failure) lists
         """
-        ret = self.client._write_record_sync(self.name, data)["data"]
+        ret = self.client._write_record_sync(
+            self.name, data, detection_mode=detection_mode, *kwargs
+        )["data"]
         return ret["success"], ret["failure"]
 
-    def send_bulk(self, data: Union[List[dict], dict]) -> "WriteSummary":
+    def send_bulk(
+        self,
+        data: Union[List[dict], dict],
+        detection_mode: str = DEFAULT_DETECTION_MODE,
+        **kwargs,
+    ) -> "WriteSummary":
         """Send a dict or list of dicts to the project.  Records
         are queued and send in parallel for performance. API
         reponses are not returned.
@@ -152,14 +191,28 @@ class Project:
 
         Args:
             data: A dict or a list of dicts.
-
+            detection_mode: Determines how to route the record through Gretel's entity
+                detection pipeline. Valid options include "fast", "all" and "none".
+                Selecting "all" will pass the records through a NLP pipeline, but
+                may increase processing latency. Selecting "none" will skip the
+                detection pipeline entirely.
+            headers: (dict) Pass in custom http headers to the request.
+            params: (dict) Pass custom query parameters to the request.
         Returns:
             A ``WriteSummary`` instance.
         """
         reader = JsonReader(data)
-        return self.client._write_records(project=self.name, reader=reader)
+        return self.client._write_records(
+            project=self.name, reader=reader, detection_mode=detection_mode, **kwargs
+        )
 
-    def send_dataframe(self, df: _DataFrameT, sample=None) -> "WriteSummary":
+    def send_dataframe(
+        self,
+        df: _DataFrameT,
+        detection_mode: str = DEFAULT_DETECTION_MODE,
+        sample=None,
+        **kwargs,
+    ) -> "WriteSummary":
         """Send the contents of a DataFrame
 
         This will convert each row of the DataFrame
@@ -174,6 +227,13 @@ class Project:
                 ``sample`` is between 0 and 1, then a fraction of the DataFrame's rows
                 will be queued for sending. So a ``sample`` of .5 will queue up half
                 of the DataFrame's rows.
+            detection_mode: Determines how to route the record through Gretel's entity
+                detection pipeline. Valid options include "fast", "all" and "none".
+                Selecting "all" will pass the records through a NLP pipeline, but
+                may increase processing latency. Selecting "none" will skip the
+                detection pipeline entirely.
+            headers: (dict) Pass in custom http headers to the request.
+            params: (dict) Pass custom query parameters to the request.
 
         NOTE:
             Sampling is randomized, not done by first N.
@@ -186,7 +246,7 @@ class Project:
             ``ValueError`` if a Pandas DataFrame was not provided
         """
         if not pd:  # pragma: no cover
-            raise RuntimeError('pandas must be installed for this feature')
+            raise RuntimeError("pandas must be installed for this feature")
 
         if not isinstance(df, pd.DataFrame):  # pragma: no cover
             raise ValueError("A Pandas DataFrame is required!")
@@ -204,7 +264,9 @@ class Project:
                 new_df = df.sample(n=sample)
 
         reader = DataFrameReader(new_df)
-        return self.client._write_records(project=self.name, reader=reader)
+        return self.client._write_records(
+            project=self.name, reader=reader, detection_mode=detection_mode, **kwargs
+        )
 
     def head(self, n: int = 5) -> _DataFrameT:
         """Get the top N records, flattened,
@@ -217,8 +279,8 @@ class Project:
         Returns a Pandas DataFrame
         """
         if not pd:  # pragma: no cover
-            raise RuntimeError('pandas must be installed to use this feature')
-        recs = self.client._get_records_sync(self.name, {"flatten": "yes", "count": n})
+            raise RuntimeError("pandas must be installed to use this feature")
+        recs = self.client._get_records_sync(self.name, params={"flatten": "yes", "count": n})
         recs = [item["data"] for item in recs]
         return pd.DataFrame(recs)
 
@@ -235,7 +297,7 @@ class Project:
             are removed and the list of records is only returned
         """
         return self.client._get_records_sync(
-            self.name, {"with_meta": "yes", "count": n, "flatten": "yes"}
+            self.name, params={"with_meta": "yes", "count": n, "flatten": "yes"}
         )
 
     def get_field_details(self, *, entity: str = None, count=500) -> List[dict]:
@@ -305,7 +367,7 @@ class Project:
             return recs
         else:
             if not pd:  # pragma: no cover
-                raise RuntimeError('cannot export as a DF without pandas installed')
+                raise RuntimeError("cannot export as a DF without pandas installed")
             return pd.DataFrame(recs)
 
     def delete(self):

--- a/src/gretel_client/transformers/__init__.py
+++ b/src/gretel_client/transformers/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F401
 from .base import FieldRef
 from .data_pipeline import DataPath
 from .data_transform_pipeline import DataTransformPipeline
@@ -36,31 +37,3 @@ except ImportError:
     FpeFloatConfig = None
     FpeStringConfig = None
     DateShiftConfig = None
-
-
-__all__ = [
-    # transformers base classes
-    "DataPath",
-    "DataTransformPipeline",
-    "DataRestorePipeline",
-    "FieldRef",
-    "StringMask",
-    # transformers implementations
-    "Bucket",
-    "BucketConfig",
-    "BucketCreationParams",
-    "get_bucket_labels_from_creation_params",
-    "bucket_creation_params_to_list",
-    "CombineConfig",
-    "ConditionalConfig",
-    "DateShiftConfig",
-    "DropConfig",
-    "FakeConstantConfig",
-    "FormatConfig",
-    "FpeFloatConfig",
-    "FpeStringConfig",
-    "RedactWithCharConfig",
-    "RedactWithLabelConfig",
-    "RedactWithStringConfig",
-    "SecureHashConfig",
-]

--- a/tests/src/gretel_client/integration/test_projects.py
+++ b/tests/src/gretel_client/integration/test_projects.py
@@ -201,7 +201,7 @@ def test_create_named_project(client: Client):
 
 def test_temporary_project(client: Client):
     with temporary_project(client) as proj:
-        proj.send([{"foo": "bar"}] * 3)
+        proj.send([{"foo": "bar"}] * 3, detection_mode="all")
         assert_check_record_count(proj, 3)
     with pytest.raises(NotFound):
         client.get_project(name=proj.name)


### PR DESCRIPTION
This pull request updates the `Project` class to support `detection_mode`, `entity_stream` and custom query and header params.

Custom headers and params are captured via `kwargs`. On the `Client`, I tried to push down param and header extraction as far down as possible into the request chain.

`_iter_records` is a notable exception. There were enough params in the function I figured it made sense to leave `entity_stream` a top-level parameter.