### PR TITLE
Add function to return console link from project instance

### DIFF
--- a/src/gretel_client/projects.py
+++ b/src/gretel_client/projects.py
@@ -400,3 +400,8 @@ class Project:
             instance after deletion, you will receive API errors.
         """
         self.client._delete_project(self.project_id)
+
+    def get_console_url(self):
+        """Returns a link to view the project from Gretel's console."""
+        console_base = self.client.base_url.replace("api", "console")
+        return f"{console_base}/{self.project_id}"

--- a/src/gretel_client/projects.py
+++ b/src/gretel_client/projects.py
@@ -401,7 +401,7 @@ class Project:
         """
         self.client._delete_project(self.project_id)
 
-    def get_console_url(self):
-        """Returns a link to view the project from Gretel's console."""
+    def get_console_url(self) -> str:
+        """Returns web link to access the project from Gretel's console."""
         console_base = self.client.base_url.replace("api", "console")
         return f"{console_base}{self.project_id}"

--- a/src/gretel_client/projects.py
+++ b/src/gretel_client/projects.py
@@ -404,4 +404,4 @@ class Project:
     def get_console_url(self):
         """Returns a link to view the project from Gretel's console."""
         console_base = self.client.base_url.replace("api", "console")
-        return f"{console_base}/{self.project_id}"
+        return f"{console_base}{self.project_id}"

--- a/tests/src/gretel_client/unit/test_projects.py
+++ b/tests/src/gretel_client/unit/test_projects.py
@@ -92,3 +92,8 @@ def test_send(client: Client):
         headers={"test": "two"},
         params={"test": "param", "detection_mode": "all"},
     )
+
+
+def test_get_console_link(client: Client):
+    p = Project(name="test-project", client=client, project_id=1234)
+    assert p.get_console_url() == "https://console.gretel.cloud/1234"


### PR DESCRIPTION
This adds a new function to the `Project` class that returns a console link. The primary use-case for this is to create a connected workflow from a standalone notebook, back into the console.