### PR TITLE
Install support packages by version and track

### DIFF
--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -163,9 +163,7 @@ class Client:
         fields = self._get(f"fields/schema/{project}", params=params)
         return fields
 
-    def _create_project(
-        self, *, name: str, desc: str, display_name: str
-    ):
+    def _create_project(self, *, name: str, desc: str, display_name: str):
         """
         NOTE(jm): not supporting display name or long description
         here yet
@@ -542,7 +540,7 @@ class Client:
             client=self,
             project_id=_id,
             desc=p["description"],
-            display_name=p["display_name"]
+            display_name=p["display_name"],
         )
 
     def get_project(
@@ -596,16 +594,20 @@ class Client:
                     client=self,
                     project_id=p["_id"],
                     desc=p["description"],
-                    display_name=p["display_name"]
+                    display_name=p["display_name"],
                 )
             except (NotFound, Unauthorized):
                 if create:
-                    return self._create_get_project(name=name, desc=desc, display_name=display_name)
+                    return self._create_get_project(
+                        name=name, desc=desc, display_name=display_name
+                    )
                 else:
                     raise
 
         if not name and create:
-            return self._create_get_project(name=None, desc=desc, display_name=display_name)
+            return self._create_get_project(
+                name=None, desc=desc, display_name=display_name
+            )
 
     def detect_entities(self, records: Union[List[dict], dict]) -> List[dict]:
         """Do real-time entity detection from a small batch of records.  This function operates
@@ -637,13 +639,21 @@ class Client:
         )
         pkg.install_packages(self.api_key, self.host)
 
-    def install_packages(self, verbose: bool = False):
+    def install_packages(
+        self, verbose: bool = False, version: str = "latest", _track: str = "stable"
+    ):
         """Installs the latest version of the Gretel Transformers package
 
         Args:
             verbose: Will print all package installation messages.
         """
-        pkg.install_packages(self.api_key, self.host, verbose)
+        pkg.install_packages(
+            api_key=self.api_key,
+            host=self.host,
+            verbose=verbose,
+            version=version,
+            _track=_track,
+        )
 
 
 def _get_or_prompt(

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -640,19 +640,20 @@ class Client:
         pkg.install_packages(self.api_key, self.host)
 
     def install_packages(
-        self, verbose: bool = False, version: str = "latest", _track: str = "stable"
+        self, verbose: bool = False, version: str = "latest"
     ):
         """Installs the latest version of the Gretel Transformers package
 
         Args:
             verbose: Will print all package installation messages.
+            version: Eg: ``1.1.0``. Determines package version to install. Specifying
+            "latest" will ensure the latest version of the package is installed.
         """
         pkg.install_packages(
             api_key=self.api_key,
             host=self.host,
             verbose=verbose,
             version=version,
-            _track=_track,
         )
 
 

--- a/src/gretel_client/pkg_installers.py
+++ b/src/gretel_client/pkg_installers.py
@@ -60,16 +60,12 @@ def _install_pip_dependency(dep: str, verbose: bool = True):
 
 
 def _get_package_endpoint(
-    package_identifier: str,
-    api_key: str,
-    host: str,
-    version: str = "latest",
-    track: str = "stable",
+    package_identifier: str, api_key: str, host: str, version: str = "latest",
 ) -> str:
     """Retrieve package installation endpoints from Gretel API"""
     pkg_resp = requests.get(
         f"{PKG_ENDPOINT.format(host)}/{package_identifier}",
-        params={"track": track, "version": version},
+        params={"version": version},
         headers={"Authorization": api_key},
     )
 
@@ -82,11 +78,7 @@ def _get_package_endpoint(
 
 
 def install_packages(
-    api_key: str,
-    host: str,
-    version: str = "latest",
-    verbose: bool = False,
-    _track: str = "stable",
+    api_key: str, host: str, version: str = "latest", verbose: bool = False,
 ):
     """Installs python support packages from Gretel's package repo.
 
@@ -94,10 +86,9 @@ def install_packages(
         api_key: Gretel API key.
         host: API endpoint for authenticating the package installation request.
         version: Determine what package version to install. The default is "latest".
-        verbose: Show installation log output
     """
     logger.info("Authenticating with package manager")
-    package_endpoint = _get_package_endpoint(HELPER_PKG, api_key, host, version, _track)
+    package_endpoint = _get_package_endpoint(HELPER_PKG, api_key, host, version)
 
     logger.info("Installing packages (this might take a while)")
     _install_pip_dependency(package_endpoint, verbose)

--- a/src/gretel_client/pkg_installers.py
+++ b/src/gretel_client/pkg_installers.py
@@ -70,7 +70,7 @@ def _get_package_endpoint(
     )
 
     if pkg_resp.status_code != 200:  # pragma: no cover
-        raise GretelInstallError("Could not fetch package details from " "endpoint.")
+        raise GretelInstallError("Could not fetch package details from endpoint.")
 
     details = pkg_resp.json()
     source_pkg = details["data"]["package"]["wheel"]

--- a/src/gretel_client/pkg_installers.py
+++ b/src/gretel_client/pkg_installers.py
@@ -59,10 +59,17 @@ def _install_pip_dependency(dep: str, verbose: bool = True):
     )
 
 
-def _get_package_endpoint(package_identifier: str, api_key: str, host: str) -> str:
+def _get_package_endpoint(
+    package_identifier: str,
+    api_key: str,
+    host: str,
+    version: str = "latest",
+    track: str = "stable",
+) -> str:
     """Retrieve package installation endpoints from Gretel API"""
     pkg_resp = requests.get(
         f"{PKG_ENDPOINT.format(host)}/{package_identifier}",
+        params={"track": track, "version": version},
         headers={"Authorization": api_key},
     )
 
@@ -74,9 +81,23 @@ def _get_package_endpoint(package_identifier: str, api_key: str, host: str) -> s
     return source_pkg
 
 
-def install_packages(api_key: str, host: str, verbose: bool = False):
+def install_packages(
+    api_key: str,
+    host: str,
+    version: str = "latest",
+    verbose: bool = False,
+    _track: str = "stable",
+):
+    """Installs python support packages from Gretel's package repo.
+
+    Args:
+        api_key: Gretel API key.
+        host: API endpoint for authenticating the package installation request.
+        version: Determine what package version to install. The default is "latest".
+        verbose: Show installation log output
+    """
     logger.info("Authenticating with package manager")
-    package_endpoint = _get_package_endpoint(HELPER_PKG, api_key, host)
+    package_endpoint = _get_package_endpoint(HELPER_PKG, api_key, host, version, _track)
 
     logger.info("Installing packages (this might take a while)")
     _install_pip_dependency(package_endpoint, verbose)

--- a/tests/src/gretel_client/unit/test_pkg_install.py
+++ b/tests/src/gretel_client/unit/test_pkg_install.py
@@ -43,6 +43,7 @@ def test_does_install_packages(popen, get_package):
     get_package.assert_called_with(
         "https://api-dev.gretel.cloud/opt/pkg/gretel-helpers",
         headers={"Authorization": "test123"},
+        params={'track': 'stable', 'version': 'latest'}
     )
 
 

--- a/tests/src/gretel_client/unit/test_pkg_install.py
+++ b/tests/src/gretel_client/unit/test_pkg_install.py
@@ -43,7 +43,7 @@ def test_does_install_packages(popen, get_package):
     get_package.assert_called_with(
         "https://api-dev.gretel.cloud/opt/pkg/gretel-helpers",
         headers={"Authorization": "test123"},
-        params={'track': 'stable', 'version': 'latest'}
+        params={'version': 'latest'}
     )
 
 


### PR DESCRIPTION
Updates the package installer to support installing Gretel packages by version and release track. There are also a couple of small formatting changes rolled in.

For example, to pin an install version the packages would be installed via

```
client.install_packages(version="0.5.1.dev0+gbaebdc8.d20201001")
```