### PR TITLE
Add support for fetching samples from API

### DIFF
--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -109,15 +109,6 @@ class WriteSummary:
         return self.success
 
 
-@dataclass
-class SampleDataset:
-    name: str
-    """The name of the dataset. This can be used as the lookup key for fetch the full dataset."""
-
-    description: str
-    """A description of the dataset"""
-
-
 class Client:
     """A single client connection to the Gretel API.
     """

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -667,13 +667,13 @@ class Client:
             version=version,
         )
 
-    def list_samples(self, include_details: bool = False) -> List[Union[str]]:
+    def list_samples(self, include_details: bool = False) -> List[Union[str, dict]]:
         """Gretel provides a number of different sample datasets that can be used to
         populate projects. This method returns a list of available samples.
 
         Args:
-            include_details: If True will include details about each sample being
-                returned. Default ``False``.
+            include_details: If ``True``, the function will return additional sample
+                details. Defult ``False``.
 
         Returns:
             A list of available sample datasets.
@@ -689,7 +689,8 @@ class Client:
     def get_sample(
         self, sample_name: str, as_df=False
     ) -> Union[List[Dict], _DataFrameT]:
-        """Returns a sample dataset by key.
+        """Returns a sample dataset by key. Use ``list_samples`` to get a list of
+        available samples.
 
         Args:
             sample_name: The name of the sample to return.

--- a/tests/src/gretel_client/integration/test_client.py
+++ b/tests/src/gretel_client/integration/test_client.py
@@ -1,6 +1,8 @@
 import os
 import pytest
 
+import pandas as pd
+
 from gretel_client.client import (
     get_cloud_client,
     Client,
@@ -41,6 +43,7 @@ def test_get_samples(client: Client):
     assert len(sample) > 0
 
     sample = client.get_sample("safecast", as_df=True)
+    assert isinstance(sample, pd.DataFrame)
     assert len(sample) > 0
 
 def test_get_sample_not_found(client: Client):

--- a/tests/src/gretel_client/integration/test_client.py
+++ b/tests/src/gretel_client/integration/test_client.py
@@ -5,6 +5,7 @@ from gretel_client.client import (
     get_cloud_client,
     Client,
 )
+from gretel_client.errors import NotFound
 
 API_KEY = os.getenv("GRETEL_TEST_API_KEY")
 
@@ -24,3 +25,24 @@ def test_detect_entities(client: Client):
 
     assert len(detected_entities) == 1
     assert len(detected_entities[0]["metadata"]["fields"]["email"]["ner"]["labels"]) == 3
+
+
+def test_list_samples(client: Client):
+    samples = client.list_samples()
+    assert len(samples) > 0
+    assert all([type(s) == str for s in samples])
+
+    samples = client.list_samples(include_details=True)
+    assert all([type(s) == dict for s in samples])
+
+
+def test_get_samples(client: Client):
+    sample = client.get_sample("safecast")
+    assert len(sample) > 0
+
+    sample = client.get_sample("safecast", as_df=True)
+    assert len(sample) > 0
+
+def test_get_sample_not_found(client: Client):
+    with pytest.raises(NotFound):
+        client.get_sample("this_sample_not_found")


### PR DESCRIPTION
From the `Client`, `list_samples` will return a list of available samples and `get_sample` will return a single sample either as a list of raw dictionaries or a `DataFrame`.