### PR TITLE
Misc client updates

### DIFF
--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -650,9 +650,7 @@ class Client:
         )
         pkg.install_packages(self.api_key, self.host)
 
-    def install_packages(
-        self, verbose: bool = False, version: str = "latest"
-    ):
+    def install_packages(self, verbose: bool = False, version: str = "latest"):
         """Installs the latest version of the Gretel Transformers package
 
         Args:
@@ -661,13 +659,12 @@ class Client:
             "latest" will ensure the latest version of the package is installed.
         """
         pkg.install_packages(
-            api_key=self.api_key,
-            host=self.host,
-            verbose=verbose,
-            version=version,
+            api_key=self.api_key, host=self.host, verbose=verbose, version=version,
         )
 
-    def list_samples(self, include_details: bool = False) -> List[Union[str, dict]]:
+    def list_samples(
+        self, include_details: bool = False, **kwargs
+    ) -> List[Union[str, dict]]:
         """Gretel provides a number of different sample datasets that can be used to
         populate projects. This method returns a list of available samples.
 
@@ -678,7 +675,8 @@ class Client:
         Returns:
             A list of available sample datasets.
         """
-        resp = self._get("records/samples")
+        headers, params = self._headers_params_from_kwargs(**kwargs)
+        resp = self._get("records/samples", params=params, headers=headers)
         if include_details:
             return [
                 {"name": name, "description": desc}

--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -687,7 +687,7 @@ class Client:
         return list(resp[DATA][SAMPLES].keys())
 
     def get_sample(
-        self, sample_name: str, as_df=False
+        self, sample_name: str, as_df=False, **kwargs
     ) -> Union[List[Dict], _DataFrameT]:
         """Returns a sample dataset by key. Use ``list_samples`` to get a list of
         available samples.
@@ -704,7 +704,9 @@ class Client:
         Raises:
             RuntimeError if a ``DataFrame`` is requested without pandas being installed.
         """
-        resp = self._get("records/samples", params={"key": sample_name})
+        headers, params = self._headers_params_from_kwargs(**kwargs)
+        params.update({"key": sample_name})
+        resp = self._get("records/samples", params=params, headers=headers)
         samples = resp[DATA][SAMPLES]
         if as_df and not pd:
             raise RuntimeError("pandas must be installed when as_df is True")

--- a/src/gretel_client/projects.py
+++ b/src/gretel_client/projects.py
@@ -404,4 +404,4 @@ class Project:
     def get_console_url(self) -> str:
         """Returns web link to access the project from Gretel's console."""
         console_base = self.client.base_url.replace("api", "console")
-        return f"{console_base}{self.project_id}"
+        return f"{console_base}{self.name}"

--- a/tests/src/gretel_client/integration/test_client.py
+++ b/tests/src/gretel_client/integration/test_client.py
@@ -7,7 +7,7 @@ from gretel_client.client import (
     get_cloud_client,
     Client,
 )
-from gretel_client.errors import NotFound
+from gretel_client.errors import NotFound, BadRequest
 
 API_KEY = os.getenv("GRETEL_TEST_API_KEY")
 
@@ -36,6 +36,10 @@ def test_list_samples(client: Client):
 
     samples = client.list_samples(include_details=True)
     assert all([type(s) == dict for s in samples])
+
+    # check to make sure query params propagate to the request
+    with pytest.raises(BadRequest):
+        client.list_samples(params={"bad_param": "yes"})
 
 
 def test_get_samples(client: Client):

--- a/tests/src/gretel_client/integration/test_client.py
+++ b/tests/src/gretel_client/integration/test_client.py
@@ -42,9 +42,9 @@ def test_get_samples(client: Client):
     sample = client.get_sample("safecast")
     assert len(sample) > 0
 
-    sample = client.get_sample("safecast", as_df=True)
+    sample = client.get_sample("safecast", as_df=True, params={"limit": 10})
     assert isinstance(sample, pd.DataFrame)
-    assert len(sample) > 0
+    assert len(sample) == 10
 
 def test_get_sample_not_found(client: Client):
     with pytest.raises(NotFound):

--- a/tests/src/gretel_client/integration/test_projects.py
+++ b/tests/src/gretel_client/integration/test_projects.py
@@ -209,6 +209,7 @@ def test_create_named_project(client: Client):
     assert p.name == name
     assert p.description == "this is super cool"
     assert p.display_name == "the project"
+    assert p.get_console_url() == f"https://console-dev.gretel.cloud/{name}"
 
     p.delete()
 

--- a/tests/src/gretel_client/unit/test_projects.py
+++ b/tests/src/gretel_client/unit/test_projects.py
@@ -95,5 +95,5 @@ def test_send(client: Client):
 
 
 def test_get_console_link(client: Client):
-    p = Project(name="test-project", client=client, project_id=1234)
-    assert p.get_console_url() == "https://console.gretel.cloud/1234"
+    p = Project(name="test-project", client=client, project_id="1234")
+    assert p.get_console_url() == "https://console.gretel.cloud/test-project"


### PR DESCRIPTION
* Allows for custom query params to propagate through `get_sample` and `list_samples` requests.
* Updates `get_console_url` to include a slug with the project `name` instead of `id`.