### PR TITLE
Add record count to write summary

### DIFF
--- a/src/gretel_client/client.py
+++ b/src/gretel_client/client.py
@@ -89,7 +89,7 @@ def _api_call(method):
     return dec
 
 
-class Counter:
+class _Counter:
     def __init__(self):
         self.count = 0
         self.lock = threading.Lock()
@@ -116,7 +116,7 @@ class WriteSummary:
     the upload operation was not successful """
 
     records_sent: int = 0
-    """Tracks the number of records written to API"""
+    """Tracks the number of records written to the API"""
 
     def __bool__(self):
         return self.success
@@ -250,7 +250,7 @@ class Client:
         self,
         project,
         write_queue,
-        record_count: Counter,
+        record_count: _Counter,
         error_list: list,
         thread_event: threading.Event,
         **kwargs,
@@ -316,7 +316,7 @@ class Client:
         sampler.set_source(iter(reader))
         write_queue = Queue(max_inflight_batches)  # backpressured worker queue
         error_list = []
-        record_count = Counter()
+        record_count = _Counter()
 
         threads = []
         thread_event = threading.Event()

--- a/tests/src/gretel_client/integration/test_client.py
+++ b/tests/src/gretel_client/integration/test_client.py
@@ -6,6 +6,7 @@ import pandas as pd
 from gretel_client.client import (
     get_cloud_client,
     Client,
+    temporary_project,
 )
 from gretel_client.errors import NotFound, BadRequest
 
@@ -26,7 +27,9 @@ def test_detect_entities(client: Client):
     detected_entities = client.detect_entities(payload)
 
     assert len(detected_entities) == 1
-    assert len(detected_entities[0]["metadata"]["fields"]["email"]["ner"]["labels"]) == 3
+    assert (
+        len(detected_entities[0]["metadata"]["fields"]["email"]["ner"]["labels"]) == 3
+    )
 
 
 def test_list_samples(client: Client):
@@ -50,6 +53,14 @@ def test_get_samples(client: Client):
     assert isinstance(sample, pd.DataFrame)
     assert len(sample) == 10
 
+
 def test_get_sample_not_found(client: Client):
     with pytest.raises(NotFound):
         client.get_sample("this_sample_not_found")
+
+
+def test_bulk_record_summary_count(client: Client):
+    samples = client.get_sample("safecast")
+    with temporary_project(client) as project:
+        summary = project.send_bulk(samples)
+        assert summary.records_sent == len(samples)

--- a/tests/src/gretel_client/integration/test_client.py
+++ b/tests/src/gretel_client/integration/test_client.py
@@ -60,7 +60,7 @@ def test_get_sample_not_found(client: Client):
 
 
 def test_bulk_record_summary_count(client: Client):
-    samples = client.get_sample("safecast")
+    samples = client.get_sample("safecast", params={"limit": 150})
     with temporary_project(client) as project:
         summary = project.send_bulk(samples)
         assert summary.records_sent == len(samples)

--- a/tests/src/gretel_client/unit/test_client.py
+++ b/tests/src/gretel_client/unit/test_client.py
@@ -348,10 +348,11 @@ def test_record_writer_csv(fake, client: Client):
 
 def test_json_writer(test_records, test_input_json_stream, client):
     client._post = Mock()
-    client._write_records(
+    summary = client._write_records(
         project="test-project", reader=JsonReader(test_input_json_stream)
     )
     client._post.assert_called_with("records/send/test-project", data=test_records)
+    assert summary.records_sent == len(test_records)
 
 
 def test_writer_params_headers(test_records, test_input_json_stream, client):


### PR DESCRIPTION
This adds a total record count to the write summary when bulk sending records. This is helpful when trying to assert that all sent records have been processed and are available from the API.

```
if project.record_count == summary.records_sent:
    ...
```