### PR TITLE
Create .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+formats:
+- pdf
+- epub
+
+python:
+  install:
+  - requirements: docs/requirements.txt


### PR DESCRIPTION
Add a `.readthedocs.yaml` to ensure control over how our RTD builds work. This file was copied from the `gretel-synthetics` project https://github.com/gretelai/gretel-synthetics/blob/master/.readthedocs.yaml

Builds had been failing ([link](https://readthedocs.org/projects/gretel-client/builds/21271918/)) because we upgraded sphinx, the default RTD builder used py37, and the newer sphinx doesnt have support for py37 ([release notes](https://www.sphinx-doc.org/en/master/changes.html#release-6-0-0-released-dec-29-2022)).

Where RTD maps py major version to full semver: https://github.com/readthedocs/readthedocs.org/blob/main/readthedocs/settings/base.py#L648