### PR TITLE
Fix failing style checks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,4 +26,4 @@ deps =
     -r{toxinidir}/test-requirements.txt
 allowlist_externals = flake8
 commands =
-    flake8 --count --select=E9,F63,F7,F82 --show-source --statistics --per-file-ignores='{toxinidir}/src/gretel_client/rest_v1/model/*.py:F821'  {toxinidir}/src {toxinidir}/tests {toxinidir}/examples 
+    flake8 --count --select=E9,F63,F7,F82 --show-source --statistics --per-file-ignores='{toxinidir}/src/gretel_client/rest_v1/**/*.py:F821'  {toxinidir}/src {toxinidir}/tests {toxinidir}/examples 


### PR DESCRIPTION
With some recent changes to our autogenerated bindings, style checks started failing. This updates some of the ignores to be more expansive and get style checks passing.