### PR TITLE
DRAFT: fixed broken docs url

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -12,4 +12,4 @@ The ``gretel-client`` package will automatically install the Gretel CLI. To ensu
 
 For more information how to setup your CLI environment, see `Environment Setup <https://docs.gretel.ai/environment-setup>`_.
 
-You may also refer to the `CLI Tutorial <https://docs.gretel.ai/cli-tutorials/redact-sensitive-pii>`_ docs for a list of guides detailing how to use the CLI.
+You may also refer to the `CLI Tutorial <https://docs.gretel.ai/examples/redact-pii>`_ docs for a list of guides detailing how to use the CLI.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ azure_deps = ["smart_open[azure]", "azure-identity"]
 setup(
     name="gretel-client",
     author="Gretel Labs, Inc.",
-    author_email="open-source@gretel.ai",
+    author_email="support@gretel.ai",
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
     description="Balance, anonymize, and share your data. With privacy guarantees.",


### PR DESCRIPTION
The previous docs URL was moved, so the link returned a 404. The link now points to the correct URL. Eventually, we should update this to a dedicated CLI tutorial page instead of our [Redact PII](https://docs.gretel.ai/examples/redact-pii) example.