### PR TITLE
Add upper bound on `numpy`.

### DIFF
--- a/requirements/tuner.txt
+++ b/requirements/tuner.txt
@@ -1,2 +1,3 @@
 optuna==3.2.0
 pandas>=1.1.0,<2
+numpy<2


### PR DESCRIPTION
Error `E   ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject`

Failed run: https://github.com/gretelai/gretel-python-client/actions/runs/9567202313/job/26374338502

Related: https://github.com/numpy/numpy/issues/26710

<details>
    <summary>Traceback</summary>

```
 /opt/hostedtoolcache/Python/3.9.19/x64/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
<frozen importlib._bootstrap>:1030: in _gcd_import
    ???
<frozen importlib._bootstrap>:1007: in _find_and_load
    ???
<frozen importlib._bootstrap>:986: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:680: in _load_unlocked
    ???
.tox/py/lib/python3.9/site-packages/_pytest/assertion/rewrite.py:171: in exec_module
    exec(co, module.__dict__)
tests/gretel_client/conftest.py:6: in <module>
    from gretel_client.config import (
src/gretel_client/__init__.py:8: in <module>
    from gretel_client.evaluation.quality_report import QualityReport
src/gretel_client/evaluation/__init__.py:2: in <module>
    from gretel_client.evaluation.quality_report import QualityReport
src/gretel_client/evaluation/quality_report.py:7: in <module>
    from gretel_client.evaluation.reports import (
src/gretel_client/evaluation/reports.py:22: in <module>
    from gretel_client.helpers import submit_docker_local
src/gretel_client/helpers.py:8: in <module>
    from gretel_client.cli.utils.parser_utils import ref_data_factory
src/gretel_client/cli/utils/parser_utils.py:11: in <module>
    from gretel_client.dataframe import _DataFrameT
src/gretel_client/dataframe.py:2: in <module>
    from pandas import DataFrame as _DataFrameT
.tox/py/lib/python3.9/site-packages/pandas/__init__.py:22: in <module>
    from pandas.compat import is_numpy_dev as _is_numpy_dev  # pyright: ignore # noqa:F401
.tox/py/lib/python3.9/site-packages/pandas/compat/__init__.py:18: in <module>
    from pandas.compat.numpy import (
.tox/py/lib/python3.9/site-packages/pandas/compat/numpy/__init__.py:4: in <module>
    from pandas.util.version import Version
.tox/py/lib/python3.9/site-packages/pandas/util/__init__.py:2: in <module>
    from pandas.util._decorators import (  # noqa:F401
.tox/py/lib/python3.9/site-packages/pandas/util/_decorators.py:14: in <module>
    from pandas._libs.properties import cache_readonly
.tox/py/lib/python3.9/site-packages/pandas/_libs/__init__.py:13: in <module>
    from pandas._libs.interval import Interval
pandas/_libs/interval.pyx:1: in init pandas._libs.interval
    ???
E   ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
```