### PR TITLE
Downgrade setuptools_scm to 8.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author="Gretel Labs, Inc.",
     author_email="support@gretel.ai",
     use_scm_version=True,
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools_scm==8.1.0"],
     description="Balance, anonymize, and share your data. With privacy guarantees.",
     url="https://github.com/gretelai/gretel-python-client",
     long_description=long_description,


### PR DESCRIPTION
Fixes action that publishes the client to PyPI: https://github.com/gretelai/gretel-python-client/actions/runs/13530953850/job/37813880510

I reproduced it here:
- ✅ with `8.1.0`: https://github.com/pimlock/gretel-python-client/actions/runs/13531888024/job/37815798247
- 🔴 with no specifier, which installs `8.2.0`: https://github.com/pimlock/gretel-python-client/actions/runs/13531924242/job/37815910908

What I did to reproduce:
- fork this repo
- create a dummy github workflow that I could trigger manually
  - side note here: in order to run a workflow, it needs to be committed on the main branch, workflows that are only defined on a branch cannot be run
- try my fix